### PR TITLE
Updated project to make use of Idris 2, version 0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Idris libraries for type safe (variational) quantum programming.
 
 ## <a id="installing"></a> Installing Idris2
 
-These libraries have been tested under Idris2 0.4.0 and 0.5.1.
+These libraries have been tested under Idris2 0.4.0, 0.5.1, and 0.6.0.
 
 The latest version of Idris can be found [here](https://www.idris-lang.org/pages/download.html), and all the instructions for installing it can be found [here](https://idris2.readthedocs.io/en/latest/tutorial/starting.html).
 

--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 .PHONY: main package clean install
 
 main:
-	idris2 -p contrib Main.idr -o main
+	idris2 -p contrib -p linear Main.idr -o main
 
 package:
 	idris2 --build qimaera.ipkg

--- a/qimaera.ipkg
+++ b/qimaera.ipkg
@@ -1,6 +1,6 @@
 package qimaera
 version = 0.1
-depends = contrib
+depends = contrib, linear
 brief = "Idris2 libraries for (variational) quantum programming"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Module `Control.Linear.LIO` was moved in 0.6.0 from the `contrib` to the `linear` folder. This change covers the required updates.

Changes were tested on a mac, using Idris2 release version 0.6.0 and latest 0.6.0-a84a5a32d. 